### PR TITLE
Accept api_key and send pebblo-server's response to daxa cloud.

### DIFF
--- a/libs/community/langchain_community/document_loaders/pebblo.py
+++ b/libs/community/langchain_community/document_loaders/pebblo.py
@@ -1,10 +1,11 @@
 """Pebblo's safe dataloader is a wrapper for document loaders"""
 
+import json
 import logging
 import os
 import uuid
 from http import HTTPStatus
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Optional
 
 import requests
 from langchain_core.documents import Document
@@ -12,6 +13,7 @@ from langchain_core.documents import Document
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_community.utilities.pebblo import (
     CLASSIFIER_URL,
+    PEBBLO_CLOUD_URL,
     PLUGIN_VERSION,
     App,
     Doc,
@@ -38,10 +40,13 @@ class PebbloSafeLoader(BaseLoader):
         name: str,
         owner: str = "",
         description: str = "",
+        api_key: Optional[str] = None,
+
     ):
         if not name or not isinstance(name, str):
             raise NameError("Must specify a valid name.")
         self.app_name = name
+        self.api_key = api_key
         self.load_id = str(uuid.uuid4())
         self.loader = langchain_loader
         self.owner = owner
@@ -52,7 +57,7 @@ class PebbloSafeLoader(BaseLoader):
         loader_name = str(type(self.loader)).split(".")[-1].split("'")[0]
         self.source_type = get_loader_type(loader_name)
         self.source_path_size = self.get_source_size(self.source_path)
-        self.source_aggr_size = 0
+        self.source_aggregate_size = 0
         self.loader_details = {
             "loader": loader_name,
             "source_path": self.source_path,
@@ -119,9 +124,12 @@ class PebbloSafeLoader(BaseLoader):
 
         Args:
             loading_end (bool, optional): Flag indicating the halt of data
-                                        loading by loader. Defaults to False.
+                                          loading by loader. Defaults to False.
         """
-        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
         doc_content = [doc.dict() for doc in self.docs]
         docs = []
         for doc in doc_content:
@@ -134,7 +142,7 @@ class PebbloSafeLoader(BaseLoader):
             doc_source_size = self.get_source_size(doc_source_path)
             page_content = str(doc.get("page_content"))
             page_content_size = self.calculate_content_size(page_content)
-            self.source_aggr_size += page_content_size
+            self.source_aggregate_size += page_content_size
             docs.append(
                 {
                     "doc": page_content,
@@ -161,28 +169,58 @@ class PebbloSafeLoader(BaseLoader):
         if loading_end is True:
             payload["loading_end"] = "true"
             if "loader_details" in payload:
-                payload["loader_details"]["source_aggr_size"] = self.source_aggr_size
+                payload["loader_details"]["source_aggregate_size"] = \
+                    self.source_aggregate_size
         payload = Doc(**payload).dict(exclude_unset=True)
         load_doc_url = f"{CLASSIFIER_URL}/v1/loader/doc"
         try:
-            resp = requests.post(
-                load_doc_url, headers=headers, json=payload, timeout=20
+            pebblo_resp = requests.post(
+                load_doc_url, headers=headers, json=payload, timeout=300
             )
-            if resp.status_code not in [HTTPStatus.OK, HTTPStatus.BAD_GATEWAY]:
+            if pebblo_resp.status_code not in [HTTPStatus.OK, HTTPStatus.BAD_GATEWAY]:
                 logger.warning(
-                    f"Received unexpected HTTP response code: {resp.status_code}"
+                    "Received unexpected HTTP response code: %s",
+                    pebblo_resp.status_code
                 )
             logger.debug(
-                f"send_loader_doc: request \
-                    url {resp.request.url}, \
-                    body {str(resp.request.body)[:999]} \
-                    len {len(resp.request.body if resp.request.body  else [])} \
-                    response status{resp.status_code} body {resp.json()}"
-            )
+                "send_loader_doc: request url %s, body %s len %s response status %s\
+                body %s",
+                pebblo_resp.request.url,
+                str(pebblo_resp.request.body)[:999],
+                str(len(pebblo_resp.request.body if pebblo_resp.request.body else [])),
+                str(pebblo_resp.status_code),
+                pebblo_resp.json(),
+                )
         except requests.exceptions.RequestException:
             logger.warning("Unable to reach pebblo server.")
-        except Exception:
-            logger.warning("An Exception caught in _send_loader_doc.")
+        except Exception as e:
+            logger.warning("An Exception caught in _send_loader_doc: %s", e)
+
+        if self.api_key:
+            try:
+                payload['docs'] = json.loads(pebblo_resp.text)['docs']
+                payload['classified'] = True
+                headers.update({"x-api-key": self.api_key})
+                pebblo_cloud_url = f"{PEBBLO_CLOUD_URL}/v1/loader/doc"
+                daxa_response = requests.post(
+                    pebblo_cloud_url, headers=headers, json=payload, timeout=20
+                )
+                logger.debug(
+                "send_loader_doc: request url %s, body %s len %s response status %s\
+                body %s",
+                daxa_response.request.url,
+                str(daxa_response.request.body)[:999],
+                str(len(
+                        daxa_response.request.body if daxa_response.request.body else []
+                        )),
+                str(daxa_response.status_code),
+                daxa_response.json(),
+                )
+            except requests.exceptions.RequestException:
+                logger.warning("Unable to reach Daxa cloud server.")
+            except Exception as e:
+                logger.warning("An Exception caught in _send_loader_doc: %s", e)
+
         if loading_end is True:
             PebbloSafeLoader.set_loader_sent()
 
@@ -206,13 +244,22 @@ class PebbloSafeLoader(BaseLoader):
 
     def _send_discover(self) -> None:
         """Send app discovery payload to pebblo-server. Internal method."""
-        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
         payload = self.app.dict(exclude_unset=True)
         app_discover_url = f"{CLASSIFIER_URL}/v1/app/discover"
         try:
             resp = requests.post(
                 app_discover_url, headers=headers, json=payload, timeout=20
             )
+            if self.api_key:
+                pebblo_cloud_url = f"{PEBBLO_CLOUD_URL}/v1/discover"
+                headers.update({"x-api-key": self.api_key})
+                _ = requests.post(
+                    pebblo_cloud_url, headers=headers, json=payload, timeout=20
+                )
             logger.debug(
                 f"send_discover: request \
                     url {resp.request.url}, \

--- a/libs/community/langchain_community/utilities/pebblo.py
+++ b/libs/community/langchain_community/utilities/pebblo.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_VERSION = "0.1.0"
 CLASSIFIER_URL = os.getenv("PEBBLO_CLASSIFIER_URL", "http://localhost:8000")
+PEBBLO_CLOUD_URL = os.getenv("PEBBLO_CLOUD_URL", "https://api.daxa.ai")
 
 # Supported loaders for Pebblo safe data loading
 file_loader = [
@@ -158,7 +159,7 @@ def get_full_path(path: str) -> str:
         or ("://" in path)
         or ("/" == path[0])
         or (path in ["unknown", "-", "in-memory"])
-    ):
+        ):
         return path
     full_path = pathlib.Path(path).resolve()
     return str(full_path)


### PR DESCRIPTION
- Added support for api_key for daxa cloud
- response of pebblo-server's loader/doc api call is now sent to daxa-cloud loader/doc api call as a payload.docs
- timeout for loader/doc post call to pebblo-server is now increased to 300 seconds