### PR TITLE
enhance source path in PebbloSafeLoaer for GoogleDriveLoader Documents.

### DIFF
--- a/libs/community/langchain_community/utilities/pebblo.py
+++ b/libs/community/langchain_community/utilities/pebblo.py
@@ -211,7 +211,11 @@ def get_loader_full_path(loader: BaseLoader) -> str:
             if location and "channel" in loader_dict:
                 channel = loader_dict["channel"]
                 if channel:
-                    location = f"{location}/{channel}"
+                    location = f"{location}/{str(channel)}"
+            if "title" in loader_dict:  # For GoogleDriveLoader
+                title = loader_dict["title"]
+                if title:
+                    location = f"{location}: {str(title)}"
         elif "path" in loader_dict:
             location = loader_dict["path"]
         elif "file_path" in loader_dict:


### PR DESCRIPTION
Enhance the source path for googleDriveLoader.

The source path of loader  (a url), is now appended with `: file-name` to it.