### PR TITLE
Updating payload of discover API

### DIFF
--- a/libs/community/langchain_community/document_loaders/pebblo.py
+++ b/libs/community/langchain_community/document_loaders/pebblo.py
@@ -327,10 +327,10 @@ class PebbloSafeLoader(BaseLoader):
             try:
                 headers.update({"x-api-key": self.api_key})
                 if pebblo_resp:
-                    pebblo_serer_version = json.loads(pebblo_resp.text).get("pebblo_server_version")
+                    pebblo_server_version = json.loads(pebblo_resp.text).get("pebblo_server_version")
                     payload.update(
                         {
-                            "pebblo_server_version": pebblo_serer_version,
+                            "pebblo_server_version": pebblo_server_version,
                             "pebblo_client_version": payload['plugin_version'],
                         }
                     )

--- a/libs/community/langchain_community/document_loaders/pebblo.py
+++ b/libs/community/langchain_community/document_loaders/pebblo.py
@@ -327,17 +327,14 @@ class PebbloSafeLoader(BaseLoader):
             try:
                 headers.update({"x-api-key": self.api_key})
                 if pebblo_resp:
-                    pebblo_resp_docs = json.loads(pebblo_resp.text).get("ai_apps_data")
+                    pebblo_serer_version = json.loads(pebblo_resp.text).get("pebblo_server_version")
                     payload.update(
                         {
-                            "pebbloServerVersion": pebblo_resp_docs.get(
-                                "pebbloServerVersion"
-                            ),
-                            "pebbloClientVersion": pebblo_resp_docs.get(
-                                "pebbloClientVersion"
-                            ),
+                            "pebblo_server_version": pebblo_serer_version,
+                            "pebblo_client_version": payload['plugin_version'],
                         }
                     )
+                    payload.pop('plugin_version')
                 pebblo_cloud_url = f"{PEBBLO_CLOUD_URL}{APP_DISCOVER_URL}"
                 pebblo_cloud_response = requests.post(
                     pebblo_cloud_url, headers=headers, json=payload, timeout=20


### PR DESCRIPTION
For Discover API in document_loaders/pebblo file, picking response locally instead of relying on API response from pebblo