### PR TITLE
781 prompt governance detect pii phi

### DIFF
--- a/libs/community/langchain_community/chains/pebblo_retrieval/utilities.py
+++ b/libs/community/langchain_community/chains/pebblo_retrieval/utilities.py
@@ -15,6 +15,7 @@ CLASSIFIER_URL = os.getenv("PEBBLO_CLASSIFIER_URL", "http://localhost:8000")
 PEBBLO_CLOUD_URL = os.getenv("PEBBLO_CLOUD_URL", "https://api.daxa.ai")
 
 PROMPT_URL = "/v1/prompt"
+PROMPT_GOV_URL = "/v1/promptgov"
 APP_DISCOVER_URL = "/v1/app/discover"
 
 


### PR DESCRIPTION
This PR introduces functionality to call the /promptgov API from Langchain whenever a prompt is sent. This integration ensures enhanced entity extraction and validation against a deny list to improve prompt governance. Initially, this feature is implemented for Pebblo, with plans to extend it to Daxa in future updates.

### Changes:-
In PebbloRetrievalQa, we have introduced a new parameter called _enable_prompt_gov, which defaults to True. When _enable_prompt_gov is True and there are values in the semantic_context.pebblo_semantic_entities.deny list, we invoke the _check_prompt_validity function. This function communicates with the /pebblogov API from Pebblo, retrieves entities from the prompt, and compares them against the deny list. If any entity from the prompt is found in the deny list, the function returns False; otherwise, it returns True. If the function returns True, the prompt is blocked.

### Output 
When we have a deny list

<img width="587" alt="Screenshot 2024-07-04 at 11 41 16 AM" src="https://github.com/daxa-ai/langchain/assets/37294591/9b09997b-de2e-43c8-af22-7bab2da358d0">

When we don't have a deny list
<img width="697" alt="Screenshot 2024-07-04 at 6 58 14 PM" src="https://github.com/daxa-ai/langchain/assets/37294591/e3308e71-4b7d-47c0-a64d-fa5038e2de72">

When we don't have any deny list but we have any entity in the prompt
<img width="697" alt="Screenshot 2024-07-04 at 7 31 36 PM" src="https://github.com/daxa-ai/langchain/assets/37294591/8ec2a3a8-408d-4a52-ad1c-82b932917ba8">


